### PR TITLE
Continuous compilation support

### DIFF
--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -119,6 +119,8 @@ class Project
   warnRE: /^\[warn\] ([^:]+):([0-9]+): (.*)/
   pointerRE: /^\[.*\] ( *)\^/
 
+  compilingRE: /^\[info\] Compiling .*/
+
   contRE:
     /^[0-9]+\. Waiting for source changes\.\.\. \(press enter to interrupt\)/
 
@@ -158,8 +160,13 @@ class Project
       do (line) =>
         # console.log(line)
         switch
+          when @compilingRE.exec(line)
+            # console.log("compilingRE #{line}")
+            @clearMessages()
+            @busyProvider.add("#{@title}: compiling")
           when @finalRE.exec(line)
             # console.log('finalRE')
+            @busyProvider.clear()
             @linter.setAllMessages(@messages)
             @pkgPath = null
           when match = @errorRE.exec(line)


### PR DESCRIPTION
Hi! There are 2 changes here:
- I added a regexp to match lines like `[info] Compiling 22 Scala sources to ....` and when it matches I add a busy-signal
- I added busy-signal `clear()` on the terminal regexp match

Probably this can be done somehow better, feel free to change it. I think you got the idea.

----

The output on continuous compilation usually looks like

```
» ~compile
[info] Updating {file:example/foo/}foo...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Compiling 22 Scala sources to example/foo/target/scala-2.11/classes...
[success] Total time: 7 s, completed Apr 23, 2017 3:54:03 PM
1. Waiting for source changes... (press enter to interrupt)
[info] Compiling 2 Scala sources to example/foo/target/scala-2.11/classes...
[success] Total time: 2 s, completed Apr 23, 2017 3:54:20 PM
2. Waiting for source changes... (press enter to interrupt)
```
